### PR TITLE
Ensure NGO deposits update balances and remove default XRPL funds

### DIFF
--- a/src/core/xrpl.py
+++ b/src/core/xrpl.py
@@ -120,9 +120,9 @@ def derive_address_from_public_key(public_key: str) -> Optional[str]:
 
 def fetch_xrp_balance_drops(classic_address: str) -> Optional[int]:
     if not XRPL_AVAILABLE or not AccountInfo:
-        # For development/testing, return a mock balance
+        # In development, treat unfunded accounts as having zero balance
         if classic_address and classic_address.startswith("r"):
-            return 10000000000  # 10,000 XRP in drops for testing
+            return 0
         return None
     client = xrpl_client()
     if not client:
@@ -132,9 +132,9 @@ def fetch_xrp_balance_drops(classic_address: str) -> Optional[int]:
         resp = client.request(req).result
         return int(resp["account_data"]["Balance"])  # drops
     except Exception:
-        # For development/testing, return a mock balance if address looks valid
+        # If the account cannot be retrieved (e.g. unfunded), report zero balance
         if classic_address and classic_address.startswith("r"):
-            return 10000000000  # 10,000 XRP in drops for testing
+            return 0
         return None
 
 

--- a/src/routers/accounts.py
+++ b/src/routers/accounts.py
@@ -428,7 +428,7 @@ def manage_recipient_balance(recipient_id: str, body: BalanceOperation, current_
             
             # Update local balance to reflect the transfer
             new_balance = current_balance + body.amount
-            
+
             # Update balance in database
             TBL_RECIPIENTS.update_item(
                 Key={"recipient_id": recipient_id},
@@ -437,8 +437,6 @@ def manage_recipient_balance(recipient_id: str, body: BalanceOperation, current_
                     ":balance": new_balance,
                 },
             )
-            
-            # Transfer completed - no need to track in database tables
         else:
             # Handle withdrawal (update balance only, no wallet transfer)
             new_balance = current_balance - body.amount

--- a/src/routers/recipients.py
+++ b/src/routers/recipients.py
@@ -14,7 +14,6 @@ from models import (
 from core.auth import get_current_ngo
 from core.database import (
     TBL_RECIPIENTS,
-    TBL_EXPENSES,
     TBL_WALLETS,
 )
 from core.xrpl import make_challenge, verify_challenge, XRPL_AVAILABLE
@@ -217,11 +216,6 @@ def manage_recipient_balance(recipient_id: str, body: BalanceOperation, current_
                 ":balance": new_balance,
             },
         )
-        
-        if body.operation_type == "deposit":
-            # Transfer completed - no need to track in database tables
-            pass
-        
         return {
             "previous_balance": current_balance,
             "new_balance": new_balance,


### PR DESCRIPTION
## Summary
- Correct NGO-to-recipient deposits to transfer funds without recording expenses
- Treat unfunded XRPL wallets as zero balance to prevent phantom 1000 XRP

## Testing
- `python -m py_compile src/routers/accounts.py src/routers/recipients.py src/core/xrpl.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c646af61e48329a8942aa81243c252