### PR TITLE
Reorder verification flow and map face scans to accounts

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -5,6 +5,7 @@ AccountType = Literal["NGO", "RECIPIENT"]
 
 
 class AccountCreate(BaseModel):
+    account_id: Optional[str] = None
     account_type: AccountType
     status: Literal["active", "blocked"] = "active"
     name: str

--- a/src/routers/accounts.py
+++ b/src/routers/accounts.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 @router.post("/accounts", tags=["accounts"])
 def create_account(body: AccountCreate):
-    account_id = str(uuid.uuid4())
+    account_id = body.account_id or str(uuid.uuid4())
     hashed_password = hash_password(body.password)
     ngo_id = body.ngo_id
     if body.account_type == "NGO" and not ngo_id:

--- a/src/routers/face.py
+++ b/src/routers/face.py
@@ -1,5 +1,5 @@
 # --- new code ---
-from typing import List
+from typing import List, Optional
 from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
 import numpy as np
 import uuid, json
@@ -47,6 +47,7 @@ def _cosine(a: np.ndarray, b: np.ndarray) -> float:
 @router.post("/face/enroll", tags=["face"])
 async def face_enroll_batch(
     files: List[UploadFile] = File(...),
+    account_id: Optional[str] = Form(None),
 ):
     # if not FACE_AVAILABLE:
     #     return {"note": "InsightFace not installed on server"}
@@ -108,7 +109,7 @@ async def face_enroll_batch(
             c = (w2[:, None] * E2).sum(axis=0)
             c = c / (np.linalg.norm(c) + 1e-12)
 
-    account_id = str(uuid.uuid4()) # TODO: make a user account and get the account id
+    account_id = account_id or str(uuid.uuid4())
     current_ngo = {"ngo_id": "demo-ngo"}  # TODO: query from account id
     row = {
         "face_id": str(uuid.uuid4()),

--- a/src/user-creation-terminal/components/user-creation-dashboard.tsx
+++ b/src/user-creation-terminal/components/user-creation-dashboard.tsx
@@ -10,18 +10,19 @@ import { FaceScanStep } from "@/components/face-scan-step"
 import { IdUploadStep } from "@/components/id-upload-step"
 import { ReviewStep } from "@/components/review-step"
 
-type Step = "welcome" | "id-upload" | "face-scan" | "review" | "complete"
+type Step = "welcome" | "face-scan" | "id-upload" | "review" | "complete"
 
 export function UserCreationDashboard() {
   const [currentStep, setCurrentStep] = useState<Step>("welcome")
   const [faceScanComplete, setFaceScanComplete] = useState(false)
   const [idUploadComplete, setIdUploadComplete] = useState(false)
   const [extractedData, setExtractedData] = useState<any>(null)
+  const [accountId, setAccountId] = useState<string | null>(null)
 
   const steps = [
     { id: "welcome", title: "Welcome", icon: User },
-    { id: "id-upload", title: "ID Upload", icon: FileText },
     { id: "face-scan", title: "Face Scan", icon: Camera },
+    { id: "id-upload", title: "ID Upload", icon: FileText },
     { id: "review", title: "Review", icon: Shield },
   ]
 
@@ -32,6 +33,7 @@ export function UserCreationDashboard() {
 
   const handleFaceScanComplete = async (faceData: any) => {
     const fd = new FormData()
+    if (accountId) fd.append("account_id", accountId)
     for (const f of faceData.files) fd.append("files", f)
     const res = await fetch("http://localhost:8000/face/enroll", {
       method: "POST",
@@ -39,18 +41,38 @@ export function UserCreationDashboard() {
     })
     const data = await res.json()
     console.log("Face enroll response:", data)
-    if (data.status !== "success") {
+    if (!data || !data.face_id) {
       alert("Face enrollment failed. Please try again.")
       return
     }
+    setAccountId(data.account_id)
     setFaceScanComplete(true)
-    setCurrentStep("review")
+    setCurrentStep("id-upload")
   }
 
-  const handleIdUploadComplete = (idData: any) => {
+  const handleIdUploadComplete = async (idData: any) => {
+    const body = {
+      account_id: accountId,
+      account_type: "RECIPIENT",
+      status: "active",
+      name: `${idData.firstName} ${idData.lastName}`,
+      email: `${idData.idNumber}@example.com`,
+      password: "changeme123",
+    }
+    const res = await fetch("http://localhost:8000/accounts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      alert("Account creation failed")
+      return
+    }
+    const data = await res.json()
+    if (data.account_id) setAccountId(data.account_id)
     setIdUploadComplete(true)
     setExtractedData(idData)
-    setCurrentStep("face-scan")
+    setCurrentStep("review")
   }
 
   const handleReviewComplete = () => {
@@ -121,17 +143,17 @@ export function UserCreationDashboard() {
               <CardContent className="space-y-6">
                 <div className="grid md:grid-cols-3 gap-4">
                   <div className="text-center p-4">
-                    <FileText className="w-12 h-12 text-primary mx-auto mb-3" />
-                    <h3 className="font-semibold mb-2">{"ID Upload"}</h3>
-                    <p className="text-sm text-muted-foreground text-pretty">
-                      {"Upload your government ID for automatic data extraction"}
-                    </p>
-                  </div>
-                  <div className="text-center p-4">
                     <Camera className="w-12 h-12 text-primary mx-auto mb-3" />
                     <h3 className="font-semibold mb-2">{"Face Scan"}</h3>
                     <p className="text-sm text-muted-foreground text-pretty">
                       {"Secure biometric verification using your device camera"}
+                    </p>
+                  </div>
+                  <div className="text-center p-4">
+                    <FileText className="w-12 h-12 text-primary mx-auto mb-3" />
+                    <h3 className="font-semibold mb-2">{"ID Upload"}</h3>
+                    <p className="text-sm text-muted-foreground text-pretty">
+                      {"Upload your government ID for automatic data extraction"}
                     </p>
                   </div>
                   <div className="text-center p-4">
@@ -143,7 +165,7 @@ export function UserCreationDashboard() {
                   </div>
                 </div>
                 <div className="flex justify-center">
-                  <Button onClick={() => setCurrentStep("id-upload")} size="lg" className="px-8">
+                  <Button onClick={() => setCurrentStep("face-scan")} size="lg" className="px-8">
                     {"Start Verification"}
                   </Button>
                 </div>
@@ -151,9 +173,9 @@ export function UserCreationDashboard() {
             </Card>
           )}
 
-          {currentStep === "id-upload" && <IdUploadStep onComplete={handleIdUploadComplete} />}
-
           {currentStep === "face-scan" && <FaceScanStep onComplete={handleFaceScanComplete} />}
+
+          {currentStep === "id-upload" && <IdUploadStep onComplete={handleIdUploadComplete} />}
 
           {currentStep === "review" && <ReviewStep extractedData={extractedData} onComplete={handleReviewComplete} />}
 


### PR DESCRIPTION
## Summary
- Allow account creation with a specified ID
- Link face enrollment to an account ID and expose it via API
- Reorder user creation so face scan occurs before ID upload and connect UI to backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c64f9e15bc83288c6b2f843ce98b42