### PR TITLE
Format wallet balances in NGO dashboard

### DIFF
--- a/src/NGO-dashboard/components/aid-recipients.tsx
+++ b/src/NGO-dashboard/components/aid-recipients.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@/hooks/use-toast"
 import { apiClient } from "@/lib/api"
 import { Recipient as APIRecipient, RecipientCreate, BalanceOperation } from "@/lib/types"
 import { useAuth } from "@/contexts/auth-context"
+import { formatCurrency } from "@/lib/utils"
 
 // Transform API recipient to local format
 interface LocalRecipient {
@@ -122,8 +123,8 @@ export function AidRecipients() {
       toast({
         title: "Deposit Successful",
         description: result.tx_hash 
-          ? `$${amount} has been transferred to ${selectedRecipient.name}'s wallet. Transaction: ${result.tx_hash.substring(0, 8)}...`
-          : `$${amount} has been deposited to ${selectedRecipient.name}'s wallet.`,
+          ? `$${formatCurrency(amount)} has been transferred to ${selectedRecipient.name}'s wallet. Transaction: ${result.tx_hash.substring(0, 8)}...`
+          : `$${formatCurrency(amount)} has been deposited to ${selectedRecipient.name}'s wallet.`,
       })
 
       setDepositAmount("")
@@ -348,7 +349,7 @@ export function AidRecipients() {
             <CardContent className="space-y-4">
               <div className="text-sm">
                 <div className="text-muted-foreground">Wallet Balance</div>
-                <div className="font-bold text-lg text-foreground">${recipient.walletBalance}</div>
+                <div className="font-bold text-lg text-foreground">${formatCurrency(recipient.walletBalance)}</div>
               </div>
 
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -373,7 +374,7 @@ export function AidRecipients() {
                   <DialogHeader>
                     <DialogTitle className="text-foreground">Deposit Money</DialogTitle>
                     <DialogDescription className="text-muted-foreground">
-                      Add funds to {recipient.name}'s wallet. Current balance: ${recipient.walletBalance}
+                      Add funds to {recipient.name}'s wallet. Current balance: ${formatCurrency(selectedRecipient.walletBalance)}
                     </DialogDescription>
                   </DialogHeader>
                   <div className="grid gap-4 py-4">

--- a/src/NGO-dashboard/components/financial-overview.tsx
+++ b/src/NGO-dashboard/components/financial-overview.tsx
@@ -6,6 +6,7 @@ import { Progress } from "@/components/ui/progress"
 import { DollarSign, TrendingUp, TrendingDown, AlertCircle, Loader2 } from "lucide-react"
 import { apiClient } from "@/lib/api"
 import { DashboardStats } from "@/lib/types"
+import { formatCurrency } from "@/lib/utils"
 
 
 export function FinancialOverview() {
@@ -137,7 +138,7 @@ export function FinancialOverview() {
             <DollarSign className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-foreground">${totalAvailable.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-foreground">${formatCurrency(totalAvailable)}</div>
             <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
               <TrendingUp className="w-3 h-3 text-green-600" />
               <span>Available for distribution</span>
@@ -151,7 +152,7 @@ export function FinancialOverview() {
             <TrendingDown className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-foreground">${totalExpenses.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-foreground">${formatCurrency(totalExpenses)}</div>
             <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
               <span>From auditor records</span>
             </div>
@@ -164,9 +165,9 @@ export function FinancialOverview() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-foreground">${lifetimeDonations.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-foreground">${formatCurrency(lifetimeDonations)}</div>
             <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-              <span>Goal: ${goal.toLocaleString()}</span>
+              <span>Goal: ${formatCurrency(goal)}</span>
               {goal > 0 && (
                 <span className="ml-2">({fundUtilizationRate.toFixed(1)}% of goal)</span>
               )}

--- a/src/NGO-dashboard/lib/utils.ts
+++ b/src/NGO-dashboard/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatCurrency(amount: number) {
+  return amount.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}


### PR DESCRIPTION
## Summary
- add formatCurrency helper
- display financial metrics with two decimal places
- show recipient wallet balances using consistent currency formatting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint must be installed)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c65568d7e88329bb0d695e2f705110