### PR TITLE
feat: support pending face enrollment with account ids

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -70,6 +70,12 @@ class SupabaseTable:
         resp = q.execute()
         return {"Items": resp.data}
 
+    def delete_item(self, Key: dict):
+        q = self.client.table(self.name).delete()
+        for k, v in Key.items():
+            q = q.eq(k, v)
+        q.execute()
+
 
 TBL_ACCOUNTS = SupabaseTable(supabase, os.getenv("ACCOUNTS_TABLE", "accounts"))
 TBL_WALLETS = SupabaseTable(supabase, os.getenv("XRPL_WALLETS_TABLE", "xrpl_wallets"))
@@ -86,3 +92,6 @@ TBL_EXPENSES = SupabaseTable(supabase, os.getenv("EXPENSES_TABLE", "expenses"))
 TBL_RECIPIENTS = SupabaseTable(supabase, os.getenv("RECIPIENTS_TABLE", "recipients"))
 TBL_NGO_EXPENSES = SupabaseTable(supabase, os.getenv("NGO_EXPENSES_TABLE", "ngo_expense"))
 TBL_FACE_MAPS = SupabaseTable(supabase, os.getenv("FACE_MAPS_TABLE", "face_maps"))
+TBL_PENDING_FACE_MAPS = SupabaseTable(
+    supabase, os.getenv("PENDING_FACE_MAPS_TABLE", "pending_face_maps")
+)

--- a/src/routers/face.py
+++ b/src/routers/face.py
@@ -4,7 +4,7 @@ import numpy as np
 import uuid, json
 
 from core.face import get_face_app, FACE_AVAILABLE
-from core.database import TBL_FACE_MAPS, TBL_ACCOUNTS
+from core.database import TBL_FACE_MAPS, TBL_PENDING_FACE_MAPS, TBL_ACCOUNTS
 from core.utils import now_iso
 
 router = APIRouter()
@@ -45,31 +45,20 @@ def _cosine(a: np.ndarray, b: np.ndarray) -> float:
 @router.post("/face/enroll", tags=["face"])
 async def face_enroll(
     files: List[UploadFile] = File(...),
-    name: str = Form(...),
+    account_id: str = Form(...),
 ):
     """
     Enroll a user face map from a short burst.
-    Accepts files and the user's name only.
-    Looks up account_id and ngo_id from TBL_ACCOUNTS.
+    Accepts files and the account's unique ID.
+    Stores embedding in the pending face map table.
     """
     if not FACE_AVAILABLE or get_face_app() is None:
         raise HTTPException(503, "InsightFace not available on server")
 
-    # Resolve account by name. Names may not be unique; handle that.
-    resp = TBL_ACCOUNTS.scan(
-        FilterExpression="#nm = :nm",
-        ExpressionAttributeNames={"#nm": "name"},
-        ExpressionAttributeValues={":nm": name},
-    )
-    accounts = resp.get("Items", []) or []
-    if not accounts:
-        raise HTTPException(404, "Account not found for this name")
-    if len(accounts) > 1:
-        # You can change this to pick the latest or require a second field to disambiguate
-        raise HTTPException(409, "Multiple accounts found with this name. Please disambiguate.")
-
-    account = accounts[0]
-    account_id = account["account_id"]
+    resp = TBL_ACCOUNTS.get_item({"account_id": account_id})
+    account = resp.get("Item")
+    if not account:
+        raise HTTPException(404, "Account not found for this account_id")
     ngo_id = account["ngo_id"]
 
     import cv2
@@ -141,13 +130,39 @@ async def face_enroll(
         "created_at": now_iso(),
         "updated_at": now_iso(),
     }
-    TBL_FACE_MAPS.put_item(Item=row)
+    TBL_PENDING_FACE_MAPS.put_item(Item=row)
 
     return {
         "face_id": row["face_id"],
         "account_id": account_id,
         "ngo_id": ngo_id,
         "frames_used": used,
+    }
+
+
+@router.post("/face/promote", tags=["face"])
+async def face_promote(
+    account_id: str = Form(...),
+):
+    """Promote a pending face embedding to verified."""
+    resp = TBL_PENDING_FACE_MAPS.scan(
+        FilterExpression="#aid = :aid",
+        ExpressionAttributeNames={"#aid": "account_id"},
+        ExpressionAttributeValues={":aid": account_id},
+    )
+    items = resp.get("Items", []) or []
+    if not items:
+        raise HTTPException(404, "Pending face map not found for this account")
+
+    row = items[0]
+    row["updated_at"] = now_iso()
+    TBL_FACE_MAPS.put_item(Item=row)
+    TBL_PENDING_FACE_MAPS.delete_item({"face_id": row["face_id"]})
+
+    return {
+        "face_id": row["face_id"],
+        "account_id": row["account_id"],
+        "ngo_id": row.get("ngo_id"),
     }
 
 @router.post("/face/identify_batch", tags=["face"])


### PR DESCRIPTION
## Summary
- add Supabase table helper for pending face maps
- enroll faces using account_id and store in pending table
- add endpoint to promote pending embeddings to verified

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c654cff13c8328816752159b622c7f