### PR TITLE
feat: complete terminal checkout flow

### DIFF
--- a/src/payment-terminal/components/camera-view.tsx
+++ b/src/payment-terminal/components/camera-view.tsx
@@ -5,9 +5,19 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Camera, CameraOff, CheckCircle } from "lucide-react"
 
+export interface VerificationResult {
+  success: boolean
+  accountId?: string
+  publicKey?: string
+}
+
 interface CameraViewProps {
   currentStep: string
-  onVerificationComplete?: () => void
+  /**
+   * Callback invoked once the server verifies (or rejects) the face.
+   * Provides match status and wallet identifiers when available.
+   */
+  onVerificationComplete?: (result: VerificationResult) => void
 }
 
 export function CameraView({ currentStep, onVerificationComplete }: CameraViewProps) {
@@ -16,6 +26,58 @@ export function CameraView({ currentStep, onVerificationComplete }: CameraViewPr
   const [cameraEnabled, setCameraEnabled] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [verificationProgress, setVerificationProgress] = useState(0)
+
+  /**
+   * Capture a burst of frames from the webcam and POST them to the
+   * FastAPI server for biometric verification. The server endpoint is
+   * implemented in `routers/face.py` and expects multiple images under
+   * the `files` field.
+   */
+  const verifyFace = async () => {
+    if (!videoRef.current) return
+
+    const canvas = document.createElement("canvas")
+    const ctx = canvas.getContext("2d")
+    const frames: Blob[] = []
+
+    // Capture 5 frames spaced ~200ms apart
+    for (let i = 0; i < 5; i++) {
+      if (!videoRef.current) break
+      canvas.width = videoRef.current.videoWidth
+      canvas.height = videoRef.current.videoHeight
+      ctx?.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height)
+      const blob: Blob = await new Promise((resolve) =>
+        canvas.toBlob((b) => resolve(b as Blob), "image/jpeg")
+      )
+      frames.push(blob)
+      // Update progress to show capture advancement (up to 50%)
+      setVerificationProgress(((i + 1) / 5) * 50)
+      await new Promise((r) => setTimeout(r, 200))
+    }
+
+    const fd = new FormData()
+    frames.forEach((blob, idx) => fd.append("files", blob, `frame_${idx}.jpg`))
+
+    try {
+      const resp = await fetch("http://localhost:8000/face/identify_batch", {
+        method: "POST",
+        body: fd,
+      })
+      const data = await resp.json().catch(() => ({}))
+      const topMatch = Array.isArray(data.matches) && data.matches[0]
+      const success = resp.ok && Boolean(topMatch)
+      setVerificationProgress(100)
+      onVerificationComplete?.({
+        success,
+        accountId: success ? topMatch.account_id : undefined,
+        publicKey: success ? topMatch.public_key : undefined,
+      })
+    } catch (err) {
+      console.error("Face verification failed", err)
+      setVerificationProgress(100)
+      onVerificationComplete?.({ success: false })
+    }
+  }
 
   const startCamera = async () => {
     try {
@@ -54,23 +116,11 @@ export function CameraView({ currentStep, onVerificationComplete }: CameraViewPr
 
   useEffect(() => {
     if (currentStep === "verification" && cameraEnabled) {
-      const interval = setInterval(() => {
-        setVerificationProgress((prev) => {
-          const newProgress = prev + Math.random() * 20
-          if (newProgress >= 100) {
-            clearInterval(interval)
-            setTimeout(() => {
-              onVerificationComplete?.()
-            }, 500)
-            return 100
-          }
-          return newProgress
-        })
-      }, 300)
-
-      return () => clearInterval(interval)
+      // Reset progress and begin verification routine once
+      setVerificationProgress(0)
+      verifyFace()
     }
-  }, [currentStep, cameraEnabled, onVerificationComplete])
+  }, [currentStep, cameraEnabled])
 
   useEffect(() => {
     return () => {

--- a/src/payment-terminal/components/payment-actions.tsx
+++ b/src/payment-terminal/components/payment-actions.tsx
@@ -12,6 +12,7 @@ interface PaymentActionsProps {
   onStepChange: (step: string) => void
   onCheckout: () => void
   onPaymentComplete: () => void
+  onWalletConfirm: () => void
   transactionData: TransactionData | null
 }
 
@@ -20,6 +21,7 @@ export function PaymentActions({
   onStepChange,
   onCheckout,
   onPaymentComplete,
+  onWalletConfirm,
   transactionData,
 }: PaymentActionsProps) {
   const [progress, setProgress] = useState(0)
@@ -44,7 +46,7 @@ export function PaymentActions({
   }
 
   const handleCancel = () => {
-    onStepChange("vendor")
+    onStepChange("checkout")
     setProgress(0)
   }
 
@@ -77,6 +79,18 @@ export function PaymentActions({
               Cancel
             </Button>
           </div>
+        )
+
+      case "wallet":
+        return (
+          <Button
+            onClick={onWalletConfirm}
+            className="w-full h-12 text-lg font-semibold"
+            size="lg"
+          >
+            <CreditCard className="w-5 h-5 mr-2" />
+            Confirm Payment
+          </Button>
         )
 
       case "processing":

--- a/src/payment-terminal/components/wallet-details.tsx
+++ b/src/payment-terminal/components/wallet-details.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Wallet } from "lucide-react"
+
+interface WalletDetailsProps {
+  walletInfo: {
+    publicKey: string
+    balanceUsd?: number
+  }
+}
+
+export function WalletDetails({ walletInfo }: WalletDetailsProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Wallet className="w-5 h-5" />
+          Wallet Details
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">Public Key</p>
+          <p className="font-mono break-all text-xs">{walletInfo.publicKey}</p>
+        </div>
+        {typeof walletInfo.balanceUsd === "number" && (
+          <div className="flex items-center justify-between pt-2 border-t">
+            <span className="text-sm text-muted-foreground">Balance (USD)</span>
+            <Badge variant="secondary">
+              ${walletInfo.balanceUsd.toFixed(2)}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/routers/face.py
+++ b/src/routers/face.py
@@ -5,7 +5,12 @@ import uuid, json
 
 from core.face import get_face_app, FACE_AVAILABLE
 from core.auth import get_current_ngo
-from core.database import TBL_FACE_MAPS, TBL_PENDING_FACE_MAPS, TBL_RECIPIENTS
+from core.database import (
+    TBL_FACE_MAPS,
+    TBL_PENDING_FACE_MAPS,
+    TBL_RECIPIENTS,
+    TBL_ACCOUNTS,
+)
 from core.utils import now_iso
 
 router = APIRouter()
@@ -317,6 +322,15 @@ async def face_identify_batch(
             "model": "buffalo_l",
             "debug": {"mismatched_dims": int(mismatched)},
         }
+
+    for m in top:
+        try:
+            acc = TBL_ACCOUNTS.get_item(Key={"account_id": m["account_id"]}).get("Item")
+            if acc:
+                m["public_key"] = acc.get("public_key")
+                m["name"] = acc.get("name")
+        except Exception:
+            continue
 
     return {
         "frames_used": int(frames_used),


### PR DESCRIPTION
## Summary
- add checkout status endpoint for vendor to push transactions to terminal
- enrich face identification with account details for wallet lookups
- display wallet info on terminal and require confirmation before processing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `pytest` (passes: 0 tests collected)


------
https://chatgpt.com/codex/tasks/task_e_68c6687d46408328bed0f5439231b5b8