### PR TITLE
Ensure checkout uses provided transaction IDs

### DIFF
--- a/src/payment-terminal/app/api/checkout/status/route.ts
+++ b/src/payment-terminal/app/api/checkout/status/route.ts
@@ -41,6 +41,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as {
+      transactionId?: string
       vendorName?: string
       items?: CheckoutItem[]
       total?: number
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest) {
       vendorName: body.vendorName,
       items: body.items,
       total: body.total,
-      transactionId: `txn_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      transactionId: body.transactionId ?? `txn_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
       storeId: body.storeId,
       programId: body.programId,
     }

--- a/src/store-dashboard/app/page.tsx
+++ b/src/store-dashboard/app/page.tsx
@@ -118,6 +118,7 @@ export default function POSCheckout() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          transactionId,
           vendorName: VENDOR_NAME,
           items: cart,
           total,


### PR DESCRIPTION
## Summary
- Pass transactionId from store checkout to payment terminal
- Allow checkout API to use incoming transactionId instead of always generating one

## Testing
- `npm test` (store-dashboard) *(fails: Missing script "test")*
- `npm test` (payment-terminal) *(fails: Missing script "test")*
- `npm run build` (store-dashboard)
- `npm run build` (payment-terminal) *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67b34d79483298a39850b384c8588