### PR TITLE
align account schema with supabase design

### DIFF
--- a/schema.txt
+++ b/schema.txt
@@ -10,11 +10,11 @@ password_hash     TEXT                            NULL
 ngo_id            UUID (Foreign Key → ngos.ngo_id) NULL
 created_at        TIMESTAMPTZ (with time zone)    DEFAULT now()
 description       TEXT                            NULL
-goal              DOUBLE PRECISION (float8)       NULL
+goal              REAL (float4)                   NULL
 lifetime_donations REAL (float4)                  NULL
 public_key        TEXT                            NULL
 private_key       TEXT                            NULL
-address           TEXT                            NOT NULL
+address          TEXT                            NULL
 --------------------------------------------------------------
 
 Table: credentials
@@ -22,7 +22,7 @@ Columns:
 --------------------------------------------------------------
 credential_id     UUID (Primary Key)              NOT NULL
 issuer_did        TEXT                            NOT NULL
-subject_id        UUID                            NULL
+subject_id        TEXT                            NULL
 role              TEXT                            NULL
 claims            JSONB                           NULL
 jwt               TEXT                            NOT NULL

--- a/src/routers/dashboard.py
+++ b/src/routers/dashboard.py
@@ -33,13 +33,14 @@ def get_dashboard_stats(current_ngo: dict = Depends(get_current_ngo)):
         available_funds = 0
         try:
             public_key = account.get("public_key")
-            if public_key:
+            addr = account.get("address")
+            if not addr and public_key:
                 addr = derive_address_from_public_key(public_key)
-                if addr:
-                    drops = fetch_xrp_balance_drops(addr)
-                    drops_val = 0 if drops is None else drops
-                    usd = convert_drops_to_usd(drops_val)
-                    available_funds = int(round(usd * 100))  # Convert to minor units (cents)
+            if addr:
+                drops = fetch_xrp_balance_drops(addr)
+                drops_val = 0 if drops is None else drops
+                usd = convert_drops_to_usd(drops_val)
+                available_funds = int(round(usd * 100))  # Convert to minor units (cents)
         except Exception:
             available_funds = 0
         

--- a/src/routers/face.py
+++ b/src/routers/face.py
@@ -12,6 +12,7 @@ from core.database import (
     TBL_ACCOUNTS,
 )
 from core.utils import now_iso
+from core.xrpl import derive_address_from_public_key
 
 router = APIRouter()
 
@@ -329,6 +330,11 @@ async def face_identify_batch(
             if acc:
                 m["public_key"] = acc.get("public_key")
                 m["name"] = acc.get("name")
+                addr = acc.get("address")
+                if not addr and acc.get("public_key"):
+                    addr = derive_address_from_public_key(acc["public_key"])
+                if addr:
+                    m["address"] = addr
         except Exception:
             continue
 

--- a/src/routers/recipients.py
+++ b/src/routers/recipients.py
@@ -176,11 +176,16 @@ def manage_recipient_balance(recipient_id: str, body: BalanceOperation, current_
             if not ngo_public_key or not ngo_private_key or not recipient_public_key:
                 raise HTTPException(status_code=500, detail="Wallet keys not properly configured")
             
-            # Derive addresses from public keys
-            from core.xrpl import derive_address_from_public_key, fetch_xrp_balance_drops, convert_drops_to_usd, transfer_between_wallets
-            
-            ngo_address = derive_address_from_public_key(ngo_public_key)
-            recipient_address = derive_address_from_public_key(recipient_public_key)
+            # Use stored addresses or derive from public keys
+            from core.xrpl import (
+                derive_address_from_public_key,
+                fetch_xrp_balance_drops,
+                convert_drops_to_usd,
+                transfer_between_wallets,
+            )
+
+            ngo_address = account.get("address") or derive_address_from_public_key(ngo_public_key)
+            recipient_address = recipient.get("address") or derive_address_from_public_key(recipient_public_key)
             
             if not ngo_address or not recipient_address:
                 raise HTTPException(status_code=500, detail="Could not derive wallet addresses")


### PR DESCRIPTION
## Summary
- persist XRPL address in accounts records
- prefer stored account and recipient addresses for balance checks and transfers
- document updated accounts schema including address field
- include stored account address in face match responses, deriving when absent

## Testing
- `python -m py_compile src/routers/accounts.py src/routers/dashboard.py src/routers/recipients.py src/routers/face.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67a21df9c83258092a60c58a66921