### PR TITLE
Integrate facial verification with payment terminal

### DIFF
--- a/src/payment-terminal/components/camera-view.tsx
+++ b/src/payment-terminal/components/camera-view.tsx
@@ -7,7 +7,7 @@ import { Camera, CameraOff, CheckCircle } from "lucide-react"
 
 export interface VerificationResult {
   success: boolean
-  accountId?: string
+  recipientId?: string
   publicKey?: string
 }
 
@@ -88,7 +88,7 @@ export function CameraView({ currentStep, onVerificationComplete }: CameraViewPr
       setVerificationProgress(100)
       onVerificationComplete?.({
         success,
-        accountId: success ? topMatch.account_id : undefined,
+        recipientId: success ? topMatch.recipient_id : undefined,
         publicKey: success ? topMatch.public_key : undefined,
       })
     } catch (err) {

--- a/src/payment-terminal/components/payment-terminal.tsx
+++ b/src/payment-terminal/components/payment-terminal.tsx
@@ -40,7 +40,7 @@ export function PaymentTerminal() {
   const [transactionData, setTransactionData] = useState<TransactionData | null>(null)
   const [vendorName, setVendorName] = useState("Block Terminal")
   const [walletInfo, setWalletInfo] = useState<{
-    accountId: string
+    recipientId: string
     publicKey: string
     balanceUsd?: number
     recipientBalance?: number
@@ -93,7 +93,7 @@ export function PaymentTerminal() {
   }
 
   const handleVerificationResult = async (result: VerificationResult) => {
-    if (result.success && result.publicKey && result.accountId) {
+    if (result.success && result.publicKey && result.recipientId) {
       setPaymentError(null)
       try {
         // Get wallet balance
@@ -105,7 +105,7 @@ export function PaymentTerminal() {
         const walletData = await walletRes.json().catch(() => ({}))
 
         // Get recipient details and balance
-        const recipientRes = await fetch(`http://localhost:8000/recipients/${result.accountId}`, {
+        const recipientRes = await fetch(`http://localhost:8000/recipients/${result.recipientId}`, {
           method: "GET",
           headers: { "Content-Type": "application/json" },
         })
@@ -125,7 +125,7 @@ export function PaymentTerminal() {
         }
 
         setWalletInfo({
-          accountId: result.accountId,
+          recipientId: result.recipientId,
           publicKey: result.publicKey,
           balanceUsd: walletData.balance_usd,
           recipientBalance: recipientBalance,
@@ -156,7 +156,7 @@ export function PaymentTerminal() {
         body: JSON.stringify({
           voucher_id: transactionData.transactionId || `voucher_${Date.now()}`,
           store_id: transactionData.storeId || "store_001",
-          recipient_id: walletInfo.accountId,
+          recipient_id: walletInfo.recipientId,
           program_id: transactionData.programId || "general_aid",
           amount_minor: Math.round(transactionData.total * 100), // Convert to minor units (cents)
           currency: "USD"

--- a/src/payment-terminal/components/wallet-details.tsx
+++ b/src/payment-terminal/components/wallet-details.tsx
@@ -6,7 +6,7 @@ import { Wallet } from "lucide-react"
 
 interface WalletDetailsProps {
   walletInfo: {
-    accountId: string
+    recipientId: string
     publicKey: string
     balanceUsd?: number
     recipientBalance?: number
@@ -24,8 +24,8 @@ export function WalletDetails({ walletInfo }: WalletDetailsProps) {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-1">
-          <p className="text-sm text-muted-foreground">Account ID</p>
-          <p className="font-mono break-all text-xs">{walletInfo.accountId}</p>
+          <p className="text-sm text-muted-foreground">Recipient ID</p>
+          <p className="font-mono break-all text-xs">{walletInfo.recipientId}</p>
         </div>
         <div className="space-y-1">
           <p className="text-sm text-muted-foreground">Public Key</p>

--- a/src/routers/face.py
+++ b/src/routers/face.py
@@ -9,7 +9,6 @@ from core.database import (
     TBL_FACE_MAPS,
     TBL_PENDING_FACE_MAPS,
     TBL_RECIPIENTS,
-    TBL_ACCOUNTS,
 )
 from core.utils import now_iso
 from core.xrpl import derive_address_from_public_key
@@ -307,7 +306,7 @@ async def face_identify_batch(
                 continue
             score = _cosine(unk, e)
             scored.append({
-                "account_id": it.get("account_id"),
+                "recipient_id": it.get("recipient_id"),
                 "face_id": it.get("face_id"),
                 "score": float(score),
             })
@@ -326,13 +325,16 @@ async def face_identify_batch(
 
     for m in top:
         try:
-            acc = TBL_ACCOUNTS.get_item(Key={"account_id": m["account_id"]}).get("Item")
-            if acc:
-                m["public_key"] = acc.get("public_key")
-                m["name"] = acc.get("name")
-                addr = acc.get("address")
-                if not addr and acc.get("public_key"):
-                    addr = derive_address_from_public_key(acc["public_key"])
+            rec = (
+                TBL_RECIPIENTS.get_item(Key={"recipient_id": m["recipient_id"]})
+                .get("Item")
+            )
+            if rec:
+                m["public_key"] = rec.get("public_key")
+                m["name"] = rec.get("name")
+                addr = rec.get("address")
+                if not addr and rec.get("public_key"):
+                    addr = derive_address_from_public_key(rec["public_key"])
                 if addr:
                     m["address"] = addr
         except Exception:
@@ -351,30 +353,87 @@ async def face_identify_batch_public(
     files: List[UploadFile] = File(...),
     top_k: int = 3,
     threshold: float = 0.40,
+    ngo_id: Optional[str] = Form(None),
 ):
-    """
-    Public version of identify_batch for payment terminal (no auth required).
-    For demo purposes, returns a mock successful identification.
-    """
-    # For demo purposes, return a mock successful identification
-    frames_used = len(files)
-    
-    if frames_used == 0:
-        raise HTTPException(400, "No images provided")
-    
-    # Mock successful match for demo - using valid UUID format
-    mock_match = {
-        "account_id": "7c18326a-eafb-4f90-804c-6926baacb38a",  # Valid UUID format
-        "public_key": "demo_public_key_abc123", 
-        "similarity": 0.85,
-        "ngo_id": "69193d5d-aa14-42a0-b556-dd000390b3a3",  # Valid UUID format
-        "ngo_name": "Volcano Relief Alliance"
-    }
-    
-    return {
-        "frames_used": frames_used,
-        "matches": [mock_match],
-        "model": "buffalo_l (demo)",
-        "search_scope": "global"
-    }
+    """Public version of identify_batch for payment terminal (no auth required)."""
 
+    unk_embs: List[np.ndarray] = []
+    frames_used = 0
+
+    for uf in files:
+        data = await uf.read()
+        if not data:
+            continue
+        try:
+            img = _img_bytes_to_ndarray(data)
+            emb, _ = _first_face_normed_embedding(img)
+            unk_embs.append(emb)
+            frames_used += 1
+        except HTTPException:
+            continue
+
+    if not unk_embs:
+        raise HTTPException(400, "No faces detected in batch")
+
+    unk = _mean_centroid(unk_embs)
+
+    if ngo_id:
+        resp = TBL_FACE_MAPS.scan(
+            FilterExpression="ngo_id = :ngo",
+            ExpressionAttributeValues={":ngo": ngo_id},
+        )
+    else:
+        resp = TBL_FACE_MAPS.scan()
+
+    items = resp.get("Items", []) or []
+
+    scored: List[dict] = []
+    mismatched = 0
+    for it in items:
+        try:
+            e = np.asarray(json.loads(it.get("embedding", "[]")), dtype=np.float32)
+            if e.size != unk.size:
+                mismatched += 1
+                continue
+            score = _cosine(unk, e)
+            scored.append({
+                "recipient_id": it.get("recipient_id"),
+                "face_id": it.get("face_id"),
+                "score": float(score),
+            })
+        except Exception:
+            continue
+
+    scored.sort(key=lambda r: r["score"], reverse=True)
+    top = scored[: max(1, top_k)]
+    if not top or top[0]["score"] < threshold:
+        return {
+            "frames_used": int(frames_used),
+            "matches": [],
+            "model": "buffalo_l",
+            "debug": {"mismatched_dims": int(mismatched)},
+        }
+
+    for m in top:
+        try:
+            rec = (
+                TBL_RECIPIENTS.get_item(Key={"recipient_id": m["recipient_id"]})
+                .get("Item")
+            )
+            if rec:
+                m["public_key"] = rec.get("public_key")
+                m["name"] = rec.get("name")
+                addr = rec.get("address")
+                if not addr and rec.get("public_key"):
+                    addr = derive_address_from_public_key(rec["public_key"])
+                if addr:
+                    m["address"] = addr
+        except Exception:
+            continue
+
+    return {
+        "frames_used": int(frames_used),
+        "matches": top,
+        "model": "buffalo_l",
+        "debug": {"mismatched_dims": int(mismatched)},
+    }


### PR DESCRIPTION
## Summary
- align face match records with recipients and expose a public identification endpoint
- surface recipient ID from camera verification to fetch balances and redeem vouchers
- display verified recipient details in payment terminal wallet panel

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c684b3eeec83298355a0d1e0bbb612